### PR TITLE
optimezes querys

### DIFF
--- a/app/views/devices/index_components/_table.html.erb
+++ b/app/views/devices/index_components/_table.html.erb
@@ -10,14 +10,24 @@
   </thead>
   <tbody>
     <% counter = 1 %>
-    <% occurrences.each do |dev_id, occurrence| %>
-      <% device = Device.find_by(device_id: dev_id).occurrences_single_device(day)  %>
+    <% sample = occurrences.map{ |key, val| key } %>
+    <% sample_two = Device.something(day, sample).map{ |dev| dev} %>
+    <% sample_three = sample_two.uniq! { |device| device.device_serial_number} %>
+    <!-- I don't understand why the group method is not working -->
+    <%# sample_three = sample_two.group(:device_serial_number) %>
+    <% sample_three = sample_three.map do |device| %>
+      <% [device, sample.find_index(device.device_serial_number)] %>
+    <% end %>
+    <% sorted = sample_three.sort_by {|device,indexx| indexx} %>
+    <% sorted = sorted.map.with_index { |(device, _sorter), index| [device, occurrences[index][1]] } %>
+    <% sorted.each do |device, occurrence| %>
+      <%# device = device.occurrences_single_device(day)  %>
       <tr>
         <th scope="row"><%= counter %></th>
-        <td><%= dev_id %></td>
-        <td><%= device.first.device_type.capitalize %></td>
+        <td><%= device.device_serial_number %></td>
+        <td><%= device.device_type.capitalize %></td>
         <td><%= occurrence %></td>
-        <td><%= device.first.calculate_growth(occurrence)  %></td>
+        <td><%= device.calculate_growth(occurrence)  %></td>
       </tr>
       <% counter += 1 %>
     <% end %>

--- a/db/migrate/20191125172518_create_devices.rb
+++ b/db/migrate/20191125172518_create_devices.rb
@@ -2,7 +2,7 @@ class CreateDevices < ActiveRecord::Migration[5.2]
   def change
     create_table :devices do |t|
       t.datetime :timestamp
-      t.string :device_id
+      t.string :device_serial_number
       t.string :device_type
       t.string :status
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -17,7 +17,7 @@ ActiveRecord::Schema.define(version: 2019_11_25_234927) do
 
   create_table "devices", force: :cascade do |t|
     t.datetime "timestamp"
-    t.string "device_id"
+    t.string "device_serial_number"
     t.string "device_type"
     t.string "status"
     t.datetime "created_at", null: false


### PR DESCRIPTION
the change in the device model from device_id to divece_serial_number was completly unnecesary, did not help to fix the active record error when grouping.